### PR TITLE
feat: Add client_host_service label

### DIFF
--- a/prometheus_fastapi_instrumentator/instrumentation.py
+++ b/prometheus_fastapi_instrumentator/instrumentation.py
@@ -195,6 +195,7 @@ class PrometheusFastApiInstrumentator:
                         response=response,
                         method=request.method.lower(),
                         service=self.service_name,
+                        client_host_service=request.headers.get["X-Abema-Client-Service"],
                         modified_handler=handler,
                         modified_status=status,
                         modified_duration=duration,

--- a/prometheus_fastapi_instrumentator/metrics.py
+++ b/prometheus_fastapi_instrumentator/metrics.py
@@ -29,6 +29,7 @@ class Info:
         response: Optional[Response],
         method: str,
         service: str,
+        client_service: str,
         modified_handler: str,
         modified_status: str,
         modified_duration: float,
@@ -53,6 +54,7 @@ class Info:
         self.response = response
         self.method = method
         self.service = service
+        self.client_service = client_service
         self.modified_handler = modified_handler
         self.modified_status = modified_status
         self.modified_duration = modified_duration
@@ -63,6 +65,7 @@ def _build_label_attribute_names(
     should_include_method: bool,
     should_include_status: bool,
     should_include_service: bool,
+    should_include_client_service: bool,
 ) -> Tuple[list, list]:
     """Builds up tuple with to be used label and attribute names.
 
@@ -71,6 +74,7 @@ def _build_label_attribute_names(
         should_include_method (bool): Should the `method` label be part of the metric?
         should_include_status (bool): Should the `status` label be part of the metric?
         should_include_service (bool): Should the `service` label be part of the metric?
+        should_include_client_service (bool): Should the `client_host_service` label be part of the metric?
 
     Returns:
         Tuple with two list elements.
@@ -99,6 +103,10 @@ def _build_label_attribute_names(
         label_names.append("service")
         info_attribute_names.append("service")
 
+    if should_include_client_service:
+        label_names.append("client_host_service")
+        info_attribute_names.append("client_host_service")
+
     return label_names, info_attribute_names
 
 
@@ -115,6 +123,7 @@ def latency(
     should_include_method: bool = True,
     should_include_status: bool = True,
     should_include_service: bool = True,
+    should_include_client_service: bool = True,
     buckets: tuple = (
         5000,
         10000,
@@ -156,6 +165,9 @@ def latency(
         should_include_service: Should the `service` label be part of the
             metric? Defaults to `True`.
 
+        should_include_client_service: Should the `client_host_service` label be part of the
+            metric? Defaults to `True`.
+
         buckets: Buckets for the histogram. Defaults to Prometheus default.
             Defaults to default buckets from Prometheus client library.
 
@@ -171,6 +183,7 @@ def latency(
         should_include_method,
         should_include_status,
         should_include_service,
+        should_include_client_service,
     )
 
     if label_names:
@@ -215,6 +228,7 @@ def request_size(
     should_include_method: bool = True,
     should_include_status: bool = True,
     should_include_service: bool = True,
+    should_include_client_service: bool = True,
 ) -> Callable[[Info], None]:
     """Record the content length of incoming requests.
 
@@ -237,6 +251,8 @@ def request_size(
             Defaults to `True`.
         should_include_service: Should the `service` label be part of the metric?
             Defaults to `True`.
+        should_include_client_service: Should the `client_host_service` label be part of the metric?
+            Defaults to `True`.
 
     Returns:
         Function that takes a single parameter `Info`.
@@ -247,6 +263,7 @@ def request_size(
         should_include_method,
         should_include_status,
         should_include_service,
+        should_include_client_service,
     )
 
     if label_names:
@@ -290,6 +307,7 @@ def response_size(
     should_include_method: bool = True,
     should_include_status: bool = True,
     should_include_service: bool = True,
+    should_include_client_service: bool = True,
 ) -> Callable[[Info], None]:
     """Record the content length of outgoing responses.
 
@@ -320,6 +338,9 @@ def response_size(
         should_include_service: Should the `service` label be part of the metric?
             Defaults to `True`.
 
+        should_include_client_service: Should the `client_host_service` label be part of the
+            metric? Defaults to `True`.
+
     Returns:
         Function that takes a single parameter `Info`.
     """
@@ -329,6 +350,7 @@ def response_size(
         should_include_method,
         should_include_status,
         should_include_service,
+        should_include_client_service,
     )
 
     if label_names:
@@ -376,6 +398,7 @@ def combined_size(
     should_include_method: bool = True,
     should_include_status: bool = True,
     should_include_service: bool = True,
+    should_include_client_service: bool = True,
 ) -> Callable[[Info], None]:
     """Record the combined content length of requests and responses.
 
@@ -406,6 +429,9 @@ def combined_size(
         should_include_service: Should the `service` label be part of the metric?
             Defaults to `True`.
 
+        should_include_client_service: Should the `client_host_service` label be part of the
+            metric? Defaults to `True`.
+
     Returns:
         Function that takes a single parameter `Info`.
     """
@@ -415,6 +441,7 @@ def combined_size(
         should_include_method,
         should_include_status,
         should_include_service,
+        should_include_client_service,
     )
 
     if label_names:
@@ -466,6 +493,7 @@ def requests(
     should_include_method: bool = True,
     should_include_status: bool = True,
     should_include_service: bool = True,
+    should_include_client_service: bool = True,
 ) -> Callable[[Info], None]:
     """Record the number of requests.
 
@@ -494,6 +522,9 @@ def requests(
         should_include_service (bool, optional): Should the `service` label be
             part of the metric? Defaults to `True`.
 
+        should_include_client_service: Should the `client_host_service` label be part of the
+            metric? Defaults to `True`.
+
     Returns:
         Function that takes a single parameter `Info`.
     """
@@ -503,6 +534,7 @@ def requests(
         should_include_method,
         should_include_status,
         should_include_service,
+        should_include_client_service,
     )
 
     if label_names:


### PR DESCRIPTION
## Description
Add `client_host_service` label which means a service name of requester to default metrics.
The value of this label is taken from ~`User-Agent`~ `X-Abema-Client-Service` header.